### PR TITLE
Parallel by default

### DIFF
--- a/05OpenMP/cpp/CMakeLists.txt
+++ b/05OpenMP/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(OpenMP)
+find_package(OpenMP REQUIRED)
 add_subdirectory(hello)
 add_subdirectory(forloop)
 add_subdirectory(wavelets)

--- a/06MPI/cpp/CMakeLists.txt
+++ b/06MPI/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 ### "hello"
 cmake_minimum_required(VERSION 2.8)
 
-find_package(MPI)
+find_package(MPI REQUIRED)
 
 if(MPI_C_FOUND)
     include_directories(${MPI_C_INCLUDE_PATH})

--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ To build and test:
 ``` bash
 git clone https://github.com/UCL-RITS/research-computing-with-cpp
 cd research-computing-with-cpp
-./build.sh
+CC=gcc-7 GXX=g++-7 ./build.sh
 ```
+
+The explicit compiler selection is needed on Mac OS for OpenMP (and possibly MPI)
+examples to build.
 
 You will need to have a bunch of stuff installed in order for the build to succeed.
 For Mac:
 * Libraries:
    * `brew install boost`
+* For building MPI and OpenMP examples:
+   * `brew install open-mpi`
+   * `brew install gcc`
 * Ruby stuff:
    * `brew install ruby`
    * `gem install liquid`


### PR DESCRIPTION
I spent a little time figuring out how to build the parallel examples on my Mac, and thought it was worth adding documentation at least.

The second commit also makes OpenMP & MPI required in a few places, so building the notes without these set up would fail. I'm happy to remove that if it causes problems - just thought it was worth making sure this does actually happen! In connection with #31 we'd want to make sure any automated testing also tested in parallel.